### PR TITLE
fix: Coverage Configuration & Pre-Commit Stages

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,11 @@
 [run]
+source = .
 omit = test/*, .venv/*
+command_line = --module pytest
+
+[report]
+show_missing = True
+omit = test/*
+sort = cover
+skip_empty = True
+# fail_under = 100

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,8 +7,6 @@ repos:
     hooks:
       - id: prettier
         files: \.(md)$
-        stages:
-          - commit
         args:
           - "--prose-wrap"
           - "always"
@@ -16,7 +14,6 @@ repos:
     rev: v0.31.1
     hooks:
       - id: markdownlint
-        verbose: true
   - repo: https://github.com/psf/black
     rev: "22.3.0" # Use the sha or tag you want to point at
     hooks:
@@ -28,17 +25,13 @@ repos:
         minimum_pre_commit_version: 2.9.2
         require_serial: true
         types_or: [python, pyi]
-        verbose: true
   - repo: https://github.com/pycqa/isort
     rev: 5.10.1
     hooks:
       - id: isort
         name: isort (python)
-        verbose: true
   - repo: https://github.com/commitizen-tools/commitizen
-    rev: master
+    rev: v2.27.1
     hooks:
       - id: commitizen
-        verbose: true
-        stage:
-          - commit
+        stages: [commit-msg]


### PR DESCRIPTION
Extended the `.coveragerc` file to report the missing lines and tweaked a few
 minor settings to improve the reliability of runs across platforms.

Corrected the `stages` for `commitizen` in `.pre-commit-config.yaml` and
 removed the verbose arguments throughout to reduce noise.