### PR TITLE
feat: Force CI to fail when no test results are found

### DIFF
--- a/.github/workflows/sql-deployment-tools-ci.yml
+++ b/.github/workflows/sql-deployment-tools-ci.yml
@@ -30,6 +30,10 @@ jobs:
         run: |
           sh ./test/run_tests.sh
 
+      - name: Validate Test Results
+        run: |
+          sh ./test/validate_results.sh
+
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action@v1
         id: test-results

--- a/test/validate_results.sh
+++ b/test/validate_results.sh
@@ -1,0 +1,21 @@
+sudo apt-get install libxml2-utils
+
+if test -f "./test-results/unit-test-results.xml"; then
+    tests=$(xmllint --xpath 'string(/testsuites/testsuite[@name="pytest"]/@tests)' ./test-results/unit-test-results.xml)
+    skipped=$(xmllint --xpath 'string(/testsuites/testsuite[@name="pytest"]/@skipped)' ./test-results/unit-test-results.xml)
+
+    if [ "$tests" = 0 ]
+    then
+            echo "No tests in test output found!!!"
+            exit 1
+    fi
+
+    if [ "$skipped" = $tests ]
+    then
+        echo "No tests ran!!!"
+        exit 1
+    fi
+else
+echo "No test results file found!!!"
+exit 1
+fi


### PR DESCRIPTION
- Added step to CI Pipeline to check the output of the "Publish Test Results" step. If no test results are found, fail the pipeline.

Test runs:
- No test results found: [FAIL](https://github.com/TheDataShed/sql-deployment-tools/runs/7040167701?check_suite_focus=true) 
- Test results found: [PASS](https://github.com/TheDataShed/sql-deployment-tools/runs/7040223573?check_suite_focus=true)

Closes #24.