### PR TITLE
feat: Added semantic versioning with commitzen

### DIFF
--- a/.cz.yaml
+++ b/.cz.yaml
@@ -1,0 +1,4 @@
+commitizen:
+  name: cz_conventional_commits
+  tag_format: $version
+  version: 0.0.1

--- a/.github/workflows/build-executable-debian.yml
+++ b/.github/workflows/build-executable-debian.yml
@@ -1,12 +1,15 @@
 name: SQL Deployment Tools - Debian
 
 on:
-  push:
-    branches:
-      - main
+  workflow_run:
+    workflows: ["SQL Deployment Tools CI"]
+    branches: [main]
+    types:
+      - completed
 
 jobs:
   build:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
 
     steps:
@@ -22,3 +25,12 @@ jobs:
           name: exe
           path: dist/debian/sql-deployment-tools
         name: Upload Executable
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          body_path: "CHANGELOG.md"
+          tag_name: ${{ env.REVISION }}
+          files: dist/debian/sql-deployment-tools
+        env:
+          GITHUB_TOKEN: ${{ secrets.COMMITIZEN }}

--- a/.github/workflows/build-executable-macosx.yml
+++ b/.github/workflows/build-executable-macosx.yml
@@ -1,12 +1,15 @@
 name: SQL Deployment Tools - Mac OSX
 
 on:
-  push:
-    branches:
-      - main
+  workflow_run:
+    workflows: ["SQL Deployment Tools CI"]
+    branches: [main]
+    types:
+      - completed
 
 jobs:
   build:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: macos-latest
 
     steps:
@@ -22,3 +25,12 @@ jobs:
           name: exe
           path: dist/macosx/sql-deployment-tools
         name: Upload Executable
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          body_path: "CHANGELOG.md"
+          tag_name: ${{ env.REVISION }}
+          files: dist/macosx/sql-deployment-tools
+        env:
+          GITHUB_TOKEN: ${{ secrets.COMMITIZEN }}

--- a/.github/workflows/build-executable-windows.yml
+++ b/.github/workflows/build-executable-windows.yml
@@ -1,12 +1,15 @@
 name: SQL Deployment Tools - Windows
 
 on:
-  push:
-    branches:
-      - main
+  workflow_run:
+    workflows: ["SQL Deployment Tools CI"]
+    branches: [main]
+    types:
+      - completed
 
 jobs:
   build:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: windows-latest
 
     steps:
@@ -22,3 +25,12 @@ jobs:
           name: exe
           path: dist/windows/sql-deployment-tools.exe
         name: Upload Executable
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          body_path: "CHANGELOG.md"
+          tag_name: ${{ env.REVISION }}
+          files: dist/windows/sql-deployment-tools.exe
+        env:
+          GITHUB_TOKEN: ${{ secrets.COMMITIZEN }}

--- a/.github/workflows/sql-deployment-tools-ci.yml
+++ b/.github/workflows/sql-deployment-tools-ci.yml
@@ -107,3 +107,22 @@ jobs:
         run: |
           echo "Validating Mac OSX Build"
           sh ./platform/mac_osx/build.sh
+
+  bump-version:
+    if: >
+      !startsWith(github.event.head_commit.message, 'bump:') &&
+      github.ref == 'refs/heads/main' &&
+      github.event_name == 'push'
+    runs-on: ubuntu-latest
+    name: "Commitizen: Bump version and create changelog"
+    steps:
+      - name: Check out
+        uses: actions/checkout@v2
+        with:
+          token: "${{ secrets.COMMITIZEN }}"
+          fetch-depth: 0
+      - name: Create bump and changelog
+        uses: commitizen-tools/commitizen-action@master
+        with:
+          github_token: ${{ secrets.COMMITIZEN }}
+          changelog_increment_filename: 'CHANGELOG.md'


### PR DESCRIPTION
Did some things and some stuff.

- Added .cz.yaml
- Added version bump on push to main to sql-deployment-tools-ci.yml
- Added release steps to the release builds:
    - build-executable-debian.yml
    - build-executable-macosx.yml
    - build-executable-windows.yml
- Release builds are now dependent upon the CI being successful on push to main so they can pick up the version bump and keep them in line with one another