### PR TITLE
fix: Exclude changelog.md from pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
     rev: v0.31.1
     hooks:
       - id: markdownlint
-        args: [-i, CHANGELOG.md]
+        args: [--ignore, CHANGELOG.md]
   - repo: https://github.com/psf/black
     rev: 22.3.0
     hooks:


### PR DESCRIPTION
Adding CHANGLEOG.md to the ignore argument for MarkdownLint in .pre-commit-config.yaml. This is an auto-generated Markdown file from Commitizen for which we have no control over the code formatting. The formatting was failing pre-commit.

Since this is an auto-generated file, I don't think we need to be checking it anyway and it was breaking the build, hence, ignored.