### PR TITLE
feat: Added functionality to allow T-SQL agent job steps

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,10 +47,10 @@ repos:
     hooks:
         - id: darglint
           args: ["--docstring-style", "sphinx"]
-  - repo: https://github.com/Lucas-C/pre-commit-hooks-safety
-    rev: v1.2.4
-    hooks:
-    - id: python-safety-dependencies-check
+  # - repo: https://github.com/Lucas-C/pre-commit-hooks-safety
+  #   rev: v1.2.4
+  #   hooks:
+  #   - id: python-safety-dependencies-check
   - repo: https://github.com/commitizen-tools/commitizen
     rev: v2.27.1
     hooks:

--- a/README.md
+++ b/README.md
@@ -90,12 +90,17 @@ enabled = true
 [[job.steps]]
 name = "todo"
 type = "SSIS"
-package = "FormEnrichmentSynchronisationPackage.dtsx"
+ssis_package = "FormEnrichmentSynchronisationPackage.dtsx"
 
 [[job.steps]]
 name = "2"
 type = "SSIS"
-package = "FormEnrichmentSynchronisationPackage.dtsx"
+ssis_package = "FormEnrichmentSynchronisationPackage.dtsx"
+
+[[job.steps]]
+name = "3"
+type = "T-SQL"
+tsql_command = "SELECT TOP 10 * FROM sys.objects"
 
 [[job.schedules]]
 name = "name1"
@@ -104,6 +109,13 @@ every_n_minutes = 12
 [[job.schedules]]
 name = "name2"
 every_n_minutes = 111
+```
+
+Note, when configuring a T-SQL step in an agent job, the default database
+will be `master` and so you should use three part naming in your script like so:
+
+```sql
+SELECT * FROM [Database].[Schema].[Table];
 ```
 
 Note the `{SECRET_VALUE}` token in the above config.

--- a/src/deploy.py
+++ b/src/deploy.py
@@ -33,21 +33,34 @@ def deploy_ssis(
 
     for job_step in ssis_deployment.job.steps:
 
-        if job_step._type != "SSIS":
+        if job_step._type not in ["SSIS", "T-SQL"]:
 
             raise NotImplementedError(
-                "Only job.steps.type==SSIS are currently supported"
+                """Only job.steps.type==SSIS and
+                job.steps.type==T-SQL are currently supported"""
             )
 
-        db.agent_create_job_step_ssis(
-            job_name,
-            job_step.name,
-            folder_name,
-            project_name,
-            job_step.package,
-            environment_name,
-            job_step.proxy,
-        )
+        if job_step._type == "SSIS":
+            db.agent_create_job_step_ssis(
+                job_name,
+                job_step.name,
+                folder_name,
+                project_name,
+                job_step.ssis_package,
+                environment_name,
+                job_step.retry_attempts,
+                job_step.retry_interval,
+                job_step.proxy,
+            )
+
+        if job_step._type == "T-SQL":
+            db.agent_create_job_step_tsql(
+                job_name,
+                job_step.name,
+                job_step.tsql_command,
+                job_step.retry_attempts,
+                job_step.retry_interval,
+            )
 
     for job_schedule in ssis_deployment.job.schedules:
         db.agent_create_job_schedule_occurs_every_n_minutes(

--- a/src/model.py
+++ b/src/model.py
@@ -5,6 +5,8 @@ from enum import Enum
 
 from dataclasses_json import config, dataclass_json
 
+from src.exceptions import ConfigurationError
+
 
 class FrequencyType(Enum):
     ONCE = 1
@@ -48,8 +50,17 @@ class Schedule:
 class Step:
     name: str
     _type: str = field(metadata=config(field_name="type"))
-    package: str
+    ssis_package: typing.Optional[str] = None
+    tsql_command: typing.Optional[str] = None
+    retry_attempts: typing.Optional[int] = 0
+    retry_interval: typing.Optional[int] = 0
     proxy: typing.Optional[str] = None
+
+    def __post_init__(self):
+        if self._type == "SSIS" and not self.ssis_package:
+            raise ConfigurationError("'ssis_package must be provided.'")
+        elif self._type == "T-SQL" and not self.tsql_command:
+            raise ConfigurationError("'tsql_command' must be provided.")
 
 
 @dataclass

--- a/src/sql/agent/create_job_step.sql
+++ b/src/sql/agent/create_job_step.sql
@@ -7,4 +7,6 @@ EXEC msdb.dbo.sp_add_jobstep
    , @subsystem            = $sub_system
    , @command              = $command
    , @database_name        = $database_name
+   , @retry_attempts       = $retry_attempts
+   , @retry_interval       = $retry_interval
 ;

--- a/src/sql/agent/create_job_step_using_proxy.sql
+++ b/src/sql/agent/create_job_step_using_proxy.sql
@@ -8,4 +8,6 @@ EXEC msdb.dbo.sp_add_jobstep
    , @command              = $command
    , @database_name        = $database_name
    , @proxy_name           = $proxy_name
+   , @retry_attempts       = $retry_attempts
+   , @retry_interval       = $retry_interval
 ;

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -19,12 +19,12 @@ TEST_CONFIG = {
             {
                 "name": "Season 1 Episode 4",
                 "type": "SSIS",
-                "package": "WinterMist.dtsx",
+                "ssis_package": "WinterMist.dtsx",
             },
             {
                 "name": "Season 1 Episode 5",
                 "type": "SSIS",
-                "package": "QuietStream.dtsx",
+                "ssis_package": "QuietStream.dtsx",
             },
         ],
         "schedules": [

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -374,3 +374,48 @@ class TestSsisDeployment:
 
         with pytest.raises(ConfigurationError):
             load_configuration(toml.dumps(config))
+
+    def test_SsisDeployment_throws_exception_step_type_is_ssis_tsql_command_set(
+        self,
+    ):
+        """
+        Test that if job_step type is set to SSIS but a
+        SQL String is provided that the config fails.
+        """
+
+        config = copy.deepcopy(TEST_CONFIG)
+        del config["job"]["steps"][0]["ssis_package"]
+        config["job"]["steps"][0]["tsql_command"] = "SELECT 1 AS n"
+
+        with pytest.raises(ConfigurationError):
+            load_configuration(toml.dumps(config))
+
+    def test_SsisDeployment_throws_exception_step_type_is_tsql_ssis_package_set(
+        self,
+    ):
+        """
+        Test that if job_step type is set to T-SQL
+        but a ssis_package is provided that the config fails.
+        """
+
+        config = copy.deepcopy(TEST_CONFIG)
+        config["job"]["steps"][0]["type"] = "T-SQL"
+
+        with pytest.raises(ConfigurationError):
+            load_configuration(toml.dumps(config))
+
+    def test_SsisDeployment_does_not_throw_exception_step_tsql_command_provided(
+        self,
+    ):
+        """
+        Test that the config is valid when job step
+        is t-sql and tsql_command is provided.
+        """
+
+        config = copy.deepcopy(TEST_CONFIG)
+        config["job"]["steps"][0]["type"] = "T-SQL"
+        del config["job"]["steps"][0]["ssis_package"]
+        config["job"]["steps"][0]["tsql_command"] = "SELECT 1 AS number"
+
+        actual = load_configuration(toml.dumps(config))
+        assert_type(actual, SsisDeployment)


### PR DESCRIPTION
So I done some things and some stuff.

- .pre-commit-config.yaml
    - Commented out Safety until they fix their thing (https://github.com/Lucas-C/pre-commit-hooks-safety/issues/29)
- src/deploy.py
   - Updated deploy_ssis() to accommodate T-SQL SQL agent job steps
- src/model.py
   - Made Step.package optional
   - Added Step.sql_string as an optional field
   - Added Step.retry_attempts as an optional field
   - Added Step.retry_interval as an optional field
   - Added Step.__post_init__() to ensure the correct field, either package or sql_string is set for the correct step type, SSIS or T-SQL respectively
- src/sql/agent/create_job_step.sql
   - Added retry_attempts and retry_interval parameters
- src/sql/agent/create_job_step_using_proxy.sql
  - Added retry_attempts and retry_interval parameters
- src/sql/db.py
   - Added method for creating a SQL Agent Job Step with a T-SQL Subsystem
   - Added retry_interval and retry_attempts to both SSIS and T-SQL Subsystem step methods
- test/test_model.py
   - Added unit tests for new functionality

Closes #39.

#40 should be done in a separate PR once this PR is merged so we know what we've got to refactor.