### PR TITLE
feat: Changes to github workflows

### DIFF
--- a/.github/workflows/build-executable-debian.yml
+++ b/.github/workflows/build-executable-debian.yml
@@ -1,5 +1,9 @@
 name: SQL Deployment Tools - Debian
 
+concurrency:
+  group: release
+  cancel-in-progress: true
+
 on:
   workflow_run:
     workflows: ["SQL Deployment Tools CI"]
@@ -8,6 +12,20 @@ on:
       - completed
 
 jobs:
+  install_dependencies:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        name: Checkout Repository
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+          cache: 'pip'
+          cache-dependency-path: ./requirements/*.txt
+      - run: pip install -r ./requirements/build.txt
+      - run: pip install -r ./requirements/test.txt
+
   build:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest

--- a/.github/workflows/build-executable-macosx.yml
+++ b/.github/workflows/build-executable-macosx.yml
@@ -1,13 +1,31 @@
 name: SQL Deployment Tools - Mac OSX
 
+concurrency:
+  group: release
+  cancel-in-progress: true
+
 on:
   workflow_run:
-    workflows: ["SQL Deployment Tools CI"]
+    workflows: ["SQL Deployment Tools CI", "SQL Deployment Tools - Debian", "SQL Deployment Tools - Windows"]
     branches: [main]
     types:
       - completed
 
 jobs:
+  install_dependencies:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        name: Checkout Repository
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+          cache: 'pip'
+          cache-dependency-path: ./requirements/*.txt
+      - run: pip install -r ./requirements/build.txt
+      - run: pip install -r ./requirements/test.txt
+
   build:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: macos-latest

--- a/.github/workflows/build-executable-windows.yml
+++ b/.github/workflows/build-executable-windows.yml
@@ -1,13 +1,31 @@
 name: SQL Deployment Tools - Windows
 
+concurrency:
+  group: release
+  cancel-in-progress: true
+
 on:
   workflow_run:
-    workflows: ["SQL Deployment Tools CI"]
+    workflows: ["SQL Deployment Tools CI", "SQL Deployment Tools - Debian"]
     branches: [main]
     types:
       - completed
 
 jobs:
+  install_dependencies:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        name: Checkout Repository
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+          cache: 'pip'
+          cache-dependency-path: ./requirements/*.txt
+      - run: pip install -r ./requirements/build.txt
+      - run: pip install -r ./requirements/test.txt
+
   build:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: windows-latest

--- a/.github/workflows/sql-deployment-tools-ci.yml
+++ b/.github/workflows/sql-deployment-tools-ci.yml
@@ -1,12 +1,16 @@
 name: SQL Deployment Tools CI
 
+concurrency:
+  group: continuous-integration
+
 on:
-  push:
-    branches:
-      - main
-      - '**'
   pull_request:
-    branches: main
+    branches:
+      - 'main'
+    types: [opened, synchronize, closed]
+  workflow_dispatch:
+    branches:
+      - '!main'
 
 jobs:
   pre_commit:
@@ -19,6 +23,20 @@ jobs:
         run: |
           python -m pip install --requirement ./requirements/test.txt
           pre-commit run --all-files
+
+  install_dependencies:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        name: Checkout Repository
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+          cache: 'pip'
+          cache-dependency-path: ./requirements/*.txt
+      - run: pip install -r ./requirements/build.txt
+      - run: pip install -r ./requirements/test.txt
 
   test:
     runs-on: ubuntu-latest
@@ -75,7 +93,7 @@ jobs:
           gistURL: https://gist.githubusercontent.com/GooseLF/dabe49eaf9102b6392e3845b2048d664
           file: badge.svg
 
-  build_debian:
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -86,35 +104,13 @@ jobs:
           echo "Validating Debian Build"
           sh ./platform/linux_debian/build.sh
 
-  build_windows:
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v3
-        name: Checkout Repository
-
-      - name: Build Executable (Windows)
-        run: |
-          echo "Validating Windows Build"
-          ./platform/windows/build.bat
-
-  build_macosx:
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v3
-        name: Checkout Repository
-
-      - name: Build Executable (Mac OSX)
-        run: |
-          echo "Validating Mac OSX Build"
-          sh ./platform/mac_osx/build.sh
-
   bump-version:
     if: >
       !startsWith(github.event.head_commit.message, 'bump:') &&
       github.ref == 'refs/heads/main' &&
-      github.event_name == 'push'
+      github.event.pull_request.merged == true
     runs-on: ubuntu-latest
-    needs: [pre_commit, test, build_debian, build_windows, build_macosx]
+    needs: [pre_commit, test, build]
     name: "Commitizen: Bump version and create changelog"
     steps:
       - name: Check out


### PR DESCRIPTION
Closes #49.

Made changes to GitHub workflows.

- .github/workflows/sql-deployment-tools-ci.yml
   - Added concurrency setting
   - Changed run trigger to pull request only and added workflow_dispatch for manual builds against any branch that isn't main
   - Cached python dependencies
   - Removed Windows and Mac OSX builds from this CI, just keep Ubuntu to keep costs and usage down
   - Changed condition for bumping the version to only bump on PR merge

- .github/workflows/build-executable-debian.yml
  - Added concurrency settings, including cancel-in-progress
  - Added dependency caching

- .github/workflows/build-executable-windows.yml
  - Added concurrency settings, including cancel-in-progress
  - Chained CI so this will only run once the Debian build completes
  - Added dependency caching

- .github/workflows/build-executable-macosx.yml
  - Added concurrency settings, including cancel-in-progress
  - Chained CI so this will only run once the Debian and Windows builds complete
  - Added dependency caching