### PR TITLE
feat: Refining CI Run triggers

### DIFF
--- a/.github/workflows/build-executable-debian.yml
+++ b/.github/workflows/build-executable-debian.yml
@@ -1,7 +1,7 @@
 name: SQL Deployment Tools - Debian
 
 concurrency:
-  group: release
+  group: release-debian
   cancel-in-progress: true
 
 on:

--- a/.github/workflows/build-executable-macosx.yml
+++ b/.github/workflows/build-executable-macosx.yml
@@ -1,7 +1,7 @@
 name: SQL Deployment Tools - Mac OSX
 
 concurrency:
-  group: release
+  group: release-macosx
   cancel-in-progress: true
 
 on:

--- a/.github/workflows/build-executable-windows.yml
+++ b/.github/workflows/build-executable-windows.yml
@@ -1,7 +1,7 @@
 name: SQL Deployment Tools - Windows
 
 concurrency:
-  group: release
+  group: release-windows
   cancel-in-progress: true
 
 on:

--- a/.github/workflows/sql-deployment-tools-ci.yml
+++ b/.github/workflows/sql-deployment-tools-ci.yml
@@ -4,10 +4,13 @@ concurrency:
   group: continuous-integration
 
 on:
+  push:
+    branches:
+      - 'main'
   pull_request:
     branches:
       - 'main'
-    types: [opened, synchronize, closed]
+    types: [opened, synchronize]
   workflow_dispatch:
     branches:
       - '!main'


### PR DESCRIPTION
Refining run triggers for the CI as it was running on the source branch when pull_request -> closed was used as a trigger.

- .github/workflows/sql-deployment-tools.yml
  - Added a `push` trigger for the main branch since only completed PR's can "push" onto the main branch.

- .github/workflows/build-executable-debian.yml
- .github/workflows/build-executable-macosx.yml
- .github/workflows/build-executable-windows.yml
   - Altered the concurrency groups as they were cancelling each other out.