### PR TITLE
fix: Commitizen bump version condition

### DIFF
--- a/.github/workflows/sql-deployment-tools-ci.yml
+++ b/.github/workflows/sql-deployment-tools-ci.yml
@@ -111,7 +111,7 @@ jobs:
     if: >
       !startsWith(github.event.head_commit.message, 'bump:') &&
       github.ref == 'refs/heads/main' &&
-      github.event.pull_request.merged == true
+      github.event_name == 'push'
     runs-on: ubuntu-latest
     needs: [pre_commit, test, build]
     name: "Commitizen: Bump version and create changelog"


### PR DESCRIPTION
- .github/workflows/sql-deployment-tools.yml
  - Altered the condition to make the commitizen bump version task run on the main branch