### PR TITLE
feat: Decouple SQL agent from SSIS

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,54 @@ Secrets/tokens can then be injected at deployment time using the
 sql-deployment-tools deploy --replacement-tokens '{"SECRET_VALUE": "***"}'
 ```
 
+### Deploy a SQL Agent Job ONLY
+
+You don't always have to provide an *.ispac file to use this tool.
+You can use this tool to deploy an agent job on its own.
+
+#### Example configuration for an Agent Only Solution
+
+```toml
+# Required only if any of your job steps point to SSIS Packages
+project = "My Integration Services Project"
+
+# Required only if any of your job steps point to SSIS Packages
+folder = "def"
+
+# Required only if any of your job steps point to SSIS Packages
+environment = "default"
+
+[job]
+name = "whatever"
+description = "cool"
+enabled = true
+notification_email_address = "{NotificationEmailAddress}"
+
+[[job.steps]]
+name = "todo"
+type = "T-SQL"
+tsql_command = "UPDATE foo SET bar = 'foobar'"
+
+[[job.steps]]
+name = "2"
+type = "T-SQL"
+tsql_command = "SELECT TOP 10 * FROM sys.objects"
+
+[[job.schedules]]
+name = "name1"
+every_n_minutes = 12
+
+[[job.schedules]]
+name = "name2"
+every_n_minutes = 111
+```
+
+Then run the following command:
+
+```bash
+sql-deployment-tools deploy --replacement-tokens '{"SECRET_VALUE": "***"}'
+```
+
 ### Example Connection String
 
 ```text

--- a/src/model.py
+++ b/src/model.py
@@ -76,8 +76,8 @@ class Job:
 @dataclass_json
 @dataclass
 class SsisDeployment:
-    project: str
-    folder: str
+    project: typing.Optional[str] = None
+    folder: typing.Optional[str] = None
     job: Job = field(default_factory=dict)
     parameters: typing.List[Parameter] = field(default_factory=list)
     environment: str = "default"

--- a/src/sql-deployment-tools.py
+++ b/src/sql-deployment-tools.py
@@ -4,7 +4,7 @@ import os
 import sys
 
 from src.config import ConfigurationError, load_configuration
-from src.deploy import deploy_ssis
+from src.deploy import deploy_agent_job, deploy_ssis
 
 if __name__ == "__main__":
     parent_parser = argparse.ArgumentParser(description="SSIS Deployment Helper")
@@ -85,7 +85,12 @@ if __name__ == "__main__":
             configuration = configuration.format(**args.replacement_tokens)
 
         ssis_deployment = load_configuration(configuration)
-        deploy_ssis(connection_string, args.ispac, ssis_deployment)
+
+        if args.ispac:
+            deploy_ssis(connection_string, args.ispac, ssis_deployment)
+
+        if ssis_deployment.job is not None:
+            deploy_agent_job(connection_string, ssis_deployment)
 
     else:
         raise NotImplementedError(f"Command not supported: {args.command}")

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -231,45 +231,45 @@ class TestSsisDeployment:
         actual = len(load_configuration(toml.dumps(TEST_CONFIG)).parameters)
         assert actual == expected
 
-    def test_SsisDeployment_throws_an_exception_when_project_name_is_not_set(self):
+    def test_SsisDeployment_throws_no_exception_when_project_name_is_not_set(self):
         """
-        Test project is not optional.
+        Test project is optional.
         """
         config = copy.deepcopy(TEST_CONFIG)
         config["project"] = None
 
-        with pytest.raises(ConfigurationError):
-            load_configuration(toml.dumps(config))
+        actual = load_configuration(toml.dumps(config))
+        assert_type(actual, SsisDeployment)
 
-    def test_SsisDeployment_throws_an_exception_when_project_is_not_in_config(self):
+    def test_SsisDeployment_throws_no_exception_when_project_is_not_in_config(self):
         """
-        Test project is not optional.
+        Test project is optional.
         """
         config = copy.deepcopy(TEST_CONFIG)
         del config["project"]
 
-        with pytest.raises(ConfigurationError):
-            load_configuration(toml.dumps(config))
+        actual = load_configuration(toml.dumps(config))
+        assert_type(actual, SsisDeployment)
 
-    def test_SsisDeployment_throws_an_exception_when_folder_is_not_set(self):
+    def test_SsisDeployment_throws_no_exception_when_folder_is_not_set(self):
         """
-        Test folder is not optional.
+        Test folder is optional.
         """
         config = copy.deepcopy(TEST_CONFIG)
         config["folder"] = None
 
-        with pytest.raises(ConfigurationError):
-            load_configuration(toml.dumps(config))
+        actual = load_configuration(toml.dumps(config))
+        assert_type(actual, SsisDeployment)
 
-    def test_SsisDeployment_throws_an_exception_when_folder_is_in_config(self):
+    def test_SsisDeployment_throws_no_exception_when_folder_is_in_config(self):
         """
         Test folder is not optional.
         """
         config = copy.deepcopy(TEST_CONFIG)
         del config["folder"]
 
-        with pytest.raises(ConfigurationError):
-            load_configuration(toml.dumps(config))
+        actual = load_configuration(toml.dumps(config))
+        assert_type(actual, SsisDeployment)
 
     def test_SsisDeployment_environment_is_optional(self):
         """


### PR DESCRIPTION
Decoupling deployment of SSIS from the deployment of SQL Agent Jobs/steps/schedules so that the tool can be used solely for the deployment of SQL Agent.

- deploy.py
  - Introduced new method for deploying SQL Agent
  - Refactored deploy_ssis to account for changes
- sql-deployment-tools.py
  - Refactored to deploy SSIS and SQL agent separately. SSIS will now only deploy if the ispac argument is set.
- model.py
   - Made SsisDeployment.project optional
   - Made SsisDeployment.folder optional
- test/test_model.py
   - Refactored tests to account for changes