### PR TITLE
fix: Get Specific Environment Reference ID

### DIFF
--- a/src/sql/db.py
+++ b/src/sql/db.py
@@ -167,6 +167,7 @@ class Database:
             {
                 "project_name": project_name,
                 "environment_name": environment_name,
+                "folder_name": folder_name,
             },
             return_results=True,
         )[0].environment_reference_id

--- a/src/sql/ssis/get_environment_reference_id.sql
+++ b/src/sql/ssis/get_environment_reference_id.sql
@@ -1,8 +1,12 @@
-SELECT  reference_id AS environment_reference_id
-FROM    catalog.environment_references
+SELECT reference_id AS environment_reference_id
+FROM   SSISDB.catalog.environment_references
  INNER
-  JOIN catalog.projects
+  JOIN SSISDB.catalog.projects
     ON projects.project_id = environment_references.project_id
+ INNER
+  JOIN SSISDB.catalog.folders
+    ON folders.folder_id = projects.folder_id
 WHERE  environment_references.environment_name = $environment_name
 AND    projects.name = $project_name
+AND    folders.name = $folder_name
 ;


### PR DESCRIPTION
The environment reference ID was not filtering on the folder name, leading to
 situations where multiple rows might be returned.

When this occurs the result was non-deterministic and the SSIS job step would
 not be configured correctly.